### PR TITLE
Fix the forward declaration issue of the todolist::Todo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,3 +18,6 @@ android: GypAndroid.mk
 	@python deps/djinni/example/glob.py ./ '*.apk'
 
 sqlite: ./build_ios/libtodoapp.xcodeproj
+
+clean:
+	rm -rf ./build_ios ./generated-src .*~ src/.*~

--- a/android_project/TodoApp/app/jni/Application.mk
+++ b/android_project/TodoApp/app/jni/Application.mk
@@ -2,7 +2,7 @@
  
 APP_ABI := all
 APP_OPTIM := release
-APP_PLATFORM := android-8
+APP_PLATFORM := android-9
 # GCC 4.9 Toolchain
 NDK_TOOLCHAIN_VERSION = 4.9
 # GNU libc++ is the only Android STL which supports C++11 features

--- a/generated-src/cpp/todo_list.hpp
+++ b/generated-src/cpp/todo_list.hpp
@@ -3,13 +3,14 @@
 
 #pragma once
 
-#include "todo.hpp"
 #include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>
 
 namespace todolist {
+
+struct Todo;
 
 class TodoList {
 public:

--- a/src/todo_list_impl.hpp
+++ b/src/todo_list_impl.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "todo_list.hpp"
+#include "todo.hpp"
  
 namespace todolist {
  


### PR DESCRIPTION
This commit fix an issue related to the compilation issue of forward
declaration for the todolist::Todo. The djinni generates the todo.hpp
and todo_list.hpp files. The todo_list.hpp has a forward declaration of
the Todo struct. The code in todo_list.hpp before this commit was
including the file todo.hpp, but since it is an autogenerated file, it
is not recommended to do that. Instead, this commit includes the
todo.hpp in the todo_list_impl.hpp. Please, not that this requires an
update in the content for the file todo_list_impl.hpp in the tutorial
available in [1].

In addition, this commit adds an entry in the Makefile for cleaning the
files generated in the compilation process.

[1]
http://mobilecpptutorials.com/todo-app-using-djinni-and-sqlite-part-1-cplusplus/
