### PR TITLE
Fixing undefined reference to 'isnan' '__isinf' for Android NDK 11

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,3 +18,6 @@ android: GypAndroid.mk
 	@python deps/djinni/example/glob.py ./ '*.apk'
 
 sqlite: ./build_ios/libtodoapp.xcodeproj
+
+clean:
+	rm -rf ./build_ios ./generated-src .*~ src/.*~

--- a/android_project/TodoApp/app/jni/Application.mk
+++ b/android_project/TodoApp/app/jni/Application.mk
@@ -2,7 +2,7 @@
  
 APP_ABI := all
 APP_OPTIM := release
-APP_PLATFORM := android-8
+APP_PLATFORM := android-9
 # GCC 4.9 Toolchain
 NDK_TOOLCHAIN_VERSION = 4.9
 # GNU libc++ is the only Android STL which supports C++11 features

--- a/generated-src/cpp/todo_list.hpp
+++ b/generated-src/cpp/todo_list.hpp
@@ -3,13 +3,14 @@
 
 #pragma once
 
-#include "todo.hpp"
 #include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>
 
 namespace todolist {
+
+struct Todo;
 
 class TodoList {
 public:

--- a/src/todo_list_impl.hpp
+++ b/src/todo_list_impl.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "todo_list.hpp"
+#include "todo.hpp"
  
 namespace todolist {
  


### PR DESCRIPTION
As per [1], android-8 is not supported in Android NDK r11. This commit
updates the Application.mk file to avoid error "undefined reference to
'isnan' '__isinf'" while compiling the code for some platforms, such as
armeabi-v7a and armeabi.

[1] android-ndk/ndk#44
